### PR TITLE
adapt to new Open Target endpoints

### DIFF
--- a/src/kg_gen_5.py
+++ b/src/kg_gen_5.py
@@ -39,6 +39,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import os
 from tqdm.auto import tqdm
+import re
 
 import pybel
 from pybel.io.jupyter import to_jupyter
@@ -57,6 +58,126 @@ import plotly.graph_objects as go
 import plotly.express as px
 
 logger = logging.getLogger("__name__")
+
+OPENTARGETS_GRAPHQL_URL = "https://api.platform.opentargets.org/api/v4/graphql"
+def _opentargets_query(query_string, variables):
+    response = requests.post(
+        OPENTARGETS_GRAPHQL_URL,
+        json={"query": query_string, "variables": variables},
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Open Targets returned a non-JSON response.") from exc
+
+    errors = payload.get("errors") or []
+    if errors:
+        message = "; ".join(
+            error.get("message", "Unknown Open Targets GraphQL error")
+            for error in errors
+        )
+        raise ValueError(message or "Open Targets GraphQL query failed")
+
+    data = payload.get("data")
+    if data is None:
+        raise ValueError("Open Targets GraphQL response did not include data")
+
+    return data
+
+
+def opentargets_graphql_query(query_string, variables=None):
+    return _opentargets_query(query_string, variables or {})
+
+
+def _clinical_stage_to_phase(value):
+    if value is None:
+        return None
+
+    stage = str(value).strip().upper()
+    if not stage:
+        return None
+
+    if "APPROVED" in stage:
+        return 4
+
+    matches = [int(match) for match in re.findall(r"PHASE[_ ]?(\d)", stage)]
+    if not matches:
+        return None
+
+    return max(matches)
+
+
+def _extract_report_ids(clinical_reports):
+    report_ids = []
+    for report in clinical_reports or []:
+        report_id = report.get("id")
+        if report_id:
+            report_ids.append(report_id)
+    return report_ids
+
+
+def _normalize_disease_candidate_rows(disease_id, disease_name, rows):
+    normalized_rows = []
+    for row in rows or []:
+        drug = row.get("drug") or {}
+        drug_id = drug.get("id")
+        if not drug_id:
+            continue
+        normalized_rows.append(
+            {
+                "approvedSymbol": None,
+                "approvedName": None,
+                "prefName": drug.get("name"),
+                "drugType": drug.get("drugType"),
+                "drugId": drug_id,
+                "phase": _clinical_stage_to_phase(row.get("maxClinicalStage")),
+                "ctIds": _extract_report_ids(row.get("clinicalReports")),
+                "status": row.get("maxClinicalStage"),
+                "id": disease_id,
+                "disease": disease_name,
+            }
+        )
+    return normalized_rows
+
+
+def get_disease_drugs_dataframe(efo_id):
+    query_string = """
+        query ClinicalCandidatesFromDisease($my_efo_id: String!){
+          disease(efoId: $my_efo_id){
+            id
+            name
+            drugAndClinicalCandidates{
+              count
+              rows{
+                id
+                maxClinicalStage
+                drug{
+                  id
+                  name
+                  drugType
+                }
+                clinicalReports{
+                  id
+                }
+              }
+            }
+          }
+        }
+    """
+
+    payload = _opentargets_query(query_string, {"my_efo_id": efo_id})
+    disease_payload = payload.get("disease") or {}
+    rows = (disease_payload.get("drugAndClinicalCandidates") or {}).get("rows") or []
+    normalized_rows = _normalize_disease_candidate_rows(
+        disease_id=efo_id,
+        disease_name=disease_payload.get("name"),
+        rows=rows,
+    )
+
+    return pd.DataFrame(normalized_rows), disease_payload.get("name")
 
 def searchDisease(name):
     
@@ -81,15 +202,9 @@ def searchDisease(name):
     # Set base URL of GraphQL API endpoint
     base_url = "https://api.platform.opentargets.org/api/v4/graphql"
 
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-    #print(r.status_code)
+    api_response = opentargets_graphql_query(query_string, variables)
 
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
-    #print(api_response)
-
-    df = pd.DataFrame(api_response['data']['search']['hits'])
+    df = pd.DataFrame(api_response['search']['hits'])
     
     if not df.empty:
         df = df.drop(columns=['entity', 'description'])
@@ -270,15 +385,9 @@ def GetDiseaseAssociatedProteins(disease_id,index_counter=0,merged_list= []):
     # Set base URL of GraphQL API endpoint
     base_url = "https://api.platform.opentargets.org/api/v4/graphql"
 
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-    #r = requests.post(base_url, json={"query": query_string})
-    #print(r.status_code)
-
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
+    api_response = opentargets_graphql_query(query_string, variables)
     
-    result = api_response['data']['disease']['associatedTargets']['rows']
+    result = api_response['disease']['associatedTargets']['rows']
     #print(len(result))
     
     merged_list.extend(result)
@@ -357,37 +466,21 @@ def GetDiseaseAssociatedProteinsPlot(df):
 def getDrugCount(disease_id):
     
     efo_id = disease_id
-
     query_string = """
-        query associatedTargets($my_efo_id: String!){
+        query ClinicalCandidatesFromDisease($my_efo_id: String!){
           disease(efoId: $my_efo_id){
             id
             name
-            knownDrugs{
-                uniqueTargets
-                uniqueDrugs
+            drugAndClinicalCandidates{
                 count
             }
           }
         }
 
     """
-
-    # Set variables object of arguments to be passed to endpoint
     variables = {"my_efo_id": efo_id}
-
-    # Set base URL of GraphQL API endpoint
-    base_url = "https://api.platform.opentargets.org/api/v4/graphql"
-
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
-    
-    #get the count value from api_repsonse dict 
-    api_response = api_response['data']['disease']['knownDrugs']['count']
-    return(api_response)
+    data = _opentargets_query(query_string, variables)
+    return (((data.get("disease") or {}).get("drugAndClinicalCandidates")) or {}).get("count", 0)
 
 #key_gen_3 version    
 # wheel = ('-', '/', '|', '\\')
@@ -459,63 +552,16 @@ def GetDiseaseAssociatedDrugs(disease_id,CT_phase):
 
     efo_id = disease_id
     size = getDrugCount(efo_id)
+    if size > 10000:
+        return None
 
-    query_string = """
-        query associatedTargets($my_efo_id: String!, $my_size: Int){
-          disease(efoId: $my_efo_id){
-            id
-            name
-            knownDrugs(size:$my_size){
-                uniqueTargets
-                uniqueDrugs
-                count
-                rows{
-                    approvedSymbol
-                    approvedName
-                    prefName
-                    drugType
-                    drugId
-                    phase
-                    ctIds
-                }
-
-            }
-          }
-        }
-
-    """
-
-    #replace $efo_id with value from efo_id
-    #query_string = query_string.replace("$efo_id",f'"{efo_id}"')
-    #query_string = query_string.replace("$efo_id",f'"{efo_id}"')
-
-    # Set variables object of arguments to be passed to endpoint
-    variables = {"my_efo_id": efo_id, "my_size": size}
-
-    # Set base URL of GraphQL API endpoint
-    base_url = "https://api.platform.opentargets.org/api/v4/graphql"
-
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-    #r = requests.post(base_url, json={"query": query_string})
-    #print(r.status_code)
-
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
-
-    df = pd.DataFrame(api_response['data']['disease']['knownDrugs']['rows'])
-    
-    #df = df.loc[df['phase'] >= int(CT_phase),:]
-    
+    df, _ = get_disease_drugs_dataframe(efo_id)
     if not df.empty:
-        df = df.loc[df['phase'] >= int(CT_phase),:]
-        df['id'] = efo_id
-        df['disease'] = api_response['data']['disease']['name']
-        #print('Your dataframe is ready')
+        df["phase"] = pd.to_numeric(df["phase"], errors="coerce")
+        df = df.loc[df["phase"].fillna(-1) >= int(CT_phase), :]
         return(df)
-    
-    else:
-        print('No drugs found in clinical trials')
+
+    return None
         
         
 # def KG_namespace_plot(final_kg,kg_name):
@@ -588,14 +634,9 @@ def getAdverseEffectCount(chembl_id):
     # Set base URL of GraphQL API endpoint
     base_url = "https://api.platform.opentargets.org/api/v4/graphql"
 
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
+    api_response = opentargets_graphql_query(query_string, variables)
     
-    #get the count value from api_repsonse dict 
-    api_response = api_response['data']['drug']['adverseEvents']['count']
+    api_response = api_response['drug']['adverseEvents']['count']
     return(api_response)
     
 def GetAdverseEvents(chem_list):
@@ -644,15 +685,9 @@ def GetAdverseEvents(chem_list):
             # Set base URL of GraphQL API endpoint
             base_url = "https://api.platform.opentargets.org/api/v4/graphql"
 
-            # Perform POST request and check status code of response
-            r = requests.post(base_url, json={"query": query_string, "variables": variables})
-            #r = requests.post(base_url, json={"query": query_string})
-            #print(r.status_code)
+            api_response_temp = opentargets_graphql_query(query_string, variables)
 
-            # Transform API response from JSON into Python dictionary and print in console
-            api_response_temp = json.loads(r.text)
-
-            api_response_temp = api_response_temp['data']['drug']['adverseEvents']['rows']
+            api_response_temp = api_response_temp['drug']['adverseEvents']['rows']
             api_response_temp = pd.DataFrame(api_response_temp)
             api_response_temp ['chembl_id'] = chembl_id
 
@@ -1155,17 +1190,9 @@ def GetDrugWarnings(chem_list):
             # Set base URL of GraphQL API endpoint
             base_url = "https://api.platform.opentargets.org/api/v4/graphql"
 
-            # Perform POST request and check status code of response
-            r = requests.post(base_url, json={"query": query_string, "variables": variables})
-            #r = requests.post(base_url, json={"query": query_string})
-            #print(r.status_code)
+            api_response_temp = opentargets_graphql_query(query_string, variables)
 
-            # Transform API response from JSON into Python dictionary and print in console
-            api_response_temp = json.loads(r.text)
-            
-            #return(api_response_temp)
-
-            api_response_temp = api_response_temp['data']['drug']['drugWarnings']
+            api_response_temp = api_response_temp['drug']['drugWarnings']
             api_response_temp = pd.DataFrame(api_response_temp)
             api_response_temp ['chembl_id'] = chembl_id
 

--- a/src/utils_v2.py
+++ b/src/utils_v2.py
@@ -18,9 +18,124 @@ import time
 import seaborn as sns
 import pybel
 import json
+import re
 
 
 logger = logging.getLogger("__name__")
+
+OPENTARGETS_GRAPHQL_URL = "https://api.platform.opentargets.org/api/v4/graphql"
+def _opentargets_query(query_string, variables):
+    response = requests.post(
+        OPENTARGETS_GRAPHQL_URL,
+        json={"query": query_string, "variables": variables},
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Open Targets returned a non-JSON response.") from exc
+
+    errors = payload.get("errors") or []
+    if errors:
+        message = "; ".join(
+            error.get("message", "Unknown Open Targets GraphQL error")
+            for error in errors
+        )
+        raise ValueError(message or "Open Targets GraphQL query failed")
+
+    data = payload.get("data")
+    if data is None:
+        raise ValueError("Open Targets GraphQL response did not include data")
+
+    return data
+
+
+def _clinical_stage_to_phase(value):
+    if value is None:
+        return None
+
+    stage = str(value).strip().upper()
+    if not stage:
+        return None
+
+    if "APPROVED" in stage:
+        return 4
+
+    matches = [int(match) for match in re.findall(r"PHASE[_ ]?(\d)", stage)]
+    if not matches:
+        return None
+
+    return max(matches)
+
+
+def _normalize_target_candidate_rows(rows):
+    normalized_rows = []
+    for row in rows or []:
+        drug = row.get("drug") or {}
+        drug_id = drug.get("id")
+        if not drug_id:
+            continue
+
+        disease_entries = []
+        for disease_entry in row.get("diseases") or []:
+            disease = (disease_entry or {}).get("disease") or {}
+            disease_entries.append(
+                {
+                    "disease.id": disease.get("id"),
+                    "disease.name": disease.get("name"),
+                }
+            )
+
+        if not disease_entries:
+            disease_entries = [{"disease.id": None, "disease.name": None}]
+
+        for disease_entry in disease_entries:
+            normalized_rows.append(
+                {
+                    "phase": _clinical_stage_to_phase(row.get("maxClinicalStage")),
+                    "status": row.get("maxClinicalStage"),
+                    "drug.id": drug_id,
+                    "drug.name": drug.get("name"),
+                    **disease_entry,
+                }
+            )
+
+    return normalized_rows
+
+
+def get_target_drugs_dataframe(ensg_id):
+    """Return target drug rows normalized close to the legacy target dataframe."""
+    query_string = """
+        query DrugAndClinicalCandidatesQuery($ensgId: String!) {
+          target(ensemblId: $ensgId) {
+            id
+            drugAndClinicalCandidates {
+              count
+              rows {
+                id
+                maxClinicalStage
+                drug {
+                  id
+                  name
+                }
+                diseases {
+                  disease {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+
+    payload = _opentargets_query(query_string, {"ensgId": ensg_id})
+    target_payload = payload.get("target") or {}
+    rows = (target_payload.get("drugAndClinicalCandidates") or {}).get("rows") or []
+    return pd.json_normalize(_normalize_target_candidate_rows(rows))
 
 
 def RetMech(chemblIds) -> dict:
@@ -1165,43 +1280,20 @@ def filter_graph(mainGraph, vprotList):
 
 
 def getDrugsforProteins_count(ensg):
-    
-    #get_id = protein
-
     query_string = """
             
-        query KnownDrugsQuery(
-          $ensgId: String!
-          $cursor: String
-          $freeTextQuery: String
-          $size: Int = 10
-        ) {
+        query DrugAndClinicalCandidatesQuery($ensgId: String!) {
           target(ensemblId: $ensgId) {
             id
-            knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery, size: $size) {
+            drugAndClinicalCandidates {
               count
               }
             }
         }
 
     """
-
-    # Set variables object of arguments to be passed to endpoint
-    variables = {"ensgId": ensg}
-
-    # Set base URL of GraphQL API endpoint
-    base_url = "https://api.platform.opentargets.org/api/v4/graphql"
-
-    # Perform POST request and check status code of response
-    r = requests.post(base_url, json={"query": query_string, "variables": variables})
-
-    # Transform API response from JSON into Python dictionary and print in console
-    api_response = json.loads(r.text)
-    
-    
-    #get the count value from api_repsonse dict 
-    api_response = api_response['data']['target']['knownDrugs']['count']
-    return(api_response)
+    data = _opentargets_query(query_string, {"ensgId": ensg})
+    return (((data.get("target") or {}).get("drugAndClinicalCandidates")) or {}).get("count", 0)
 
 
 def getDrugsforProteins(prot_list):
@@ -1223,63 +1315,9 @@ def getDrugsforProteins(prot_list):
         #print(mapping_dict_id_symbol[prot])
         
         try:
-            count = getDrugsforProteins_count(mapping_dict_id_symbol[prot])
-
-            query_string = """
-
-                query KnownDrugsQuery(
-                  $ensgId: String!
-                  $cursor: String
-                  $freeTextQuery: String
-                  $size: Int!
-                ) {
-                  target(ensemblId: $ensgId) {
-                    id
-                    knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery, size: $size) {
-                      count
-                      cursor
-                      rows {
-                        phase
-                        status
-                        disease {
-                          id
-                          name
-                        }
-                        drug {
-                          id
-                          name
-                        }
-                      }
-                    }
-                  }
-                }
-
-
-            """
-
-            # Set variables object of arguments to be passed to endpoint
-            variables = {"ensgId": mapping_dict_id_symbol[prot], "size": count}
-
-            # Set base URL of GraphQL API endpoint
-            base_url = "https://api.platform.opentargets.org/api/v4/graphql"
-
-            # Perform POST request and check status code of response
-            r = requests.post(base_url, json={"query": query_string, "variables": variables})
-            #r = requests.post(base_url, json={"query": query_string})
-            #print(r.status_code)
-
-            # Transform API response from JSON into Python dictionary and print in console
-            api_response_temp = json.loads(r.text)
-            api_response_temp = api_response_temp['data']['target']['knownDrugs']['rows']
-            #return(api_response_temp)
-            
-            api_response_temp=pd.json_normalize(api_response_temp)
-            #return(df)
+            api_response_temp = get_target_drugs_dataframe(mapping_dict_id_symbol[prot])
             api_response_temp['Protein'] = prot
-            
-            #api_response_temp = pd.DataFrame(api_response_temp)
-            
-            
+
             api_response = pd.concat([api_response,api_response_temp])
 
 


### PR DESCRIPTION
## Summary

This change fixes a breaking incompatibility between KGG and the live Open Targets GraphQL schema. The original implementation queried disease- and target-level `knownDrugs` fields and then accessed `payload["data"]` directly. The current Open Targets API no longer supports those query shapes for the affected objects, so the server returns GraphQL `errors` instead of the expected `data` object. In practice, that schema break surfaced in KGG as `KeyError: 'data'`, which masked the real root cause and stopped KG generation early in the disease-to-drug branch.

The fix updates KGG to use the current Open Targets GraphQL model on the same base endpoint.


## Problem
### Root cause
The original KGG was written against older Open Targets query shapes:
- Disease drug lookup used:
  - `disease(efoId: ...) { knownDrugs { ... } }`
- Target drug lookup used:
  - `target(ensemblId: ...) { knownDrugs { ... } }`

They just make change yesterday (https://blog.opentargets.org/open-targets-platform-26-03-has-been-released/). Those query shapes are no longer valid against the live Open Targets GraphQL schema. The relevant schema fields have moved to the newer clinical candidate model:
- Disease:
  - `drugAndClinicalCandidates`
- Target:
  - `drugAndClinicalCandidates`



## Solution
### 1. Switched disease drug queries to the new Open Targets schema
In `src/kg_gen_5.py`, the disease drug path now follows the new query structure: query ClinicalCandidatesFromDisease

This was applied to:
- `getDrugCount(...)`
- `GetDiseaseAssociatedDrugs(...)`
- disease-drug normalization helpers local to `kg_gen_5.py`

### 2. Switched target drug queries to the new Open Targets schema

In `src/utils_v2.py`, the target drug path now uses the new target-side query structure: query DrugAndClinicalCandidatesQuery

This was applied to:
- `getDrugsforProteins_count(...)`
- `get_target_drugs_dataframe(...)`
- `getDrugsforProteins(...)`

### 3. Normalized the new response structure for downstream compatibility
The new Open Targets response is more nested than the old `knownDrugs` result. Downstream KGG code still expects flattened dataframe columns such as:
- `drugId`
- `prefName`
- `drugType`
- `phase`
- `ctIds`
- `status`
- `id`
- `disease`

To preserve compatibility with the rest of the pipeline, this PR introduces explicit normalization rather than forcing downstream code to change everywhere.



## Conclusion

This pull request fixes a break caused by upstream Open Targets schema update. The underlying issue was that KGG still queried deprecated `knownDrugs` fields while the live Open Targets platform had already moved the relevant disease- and target-drug data to `drugAndClinicalCandidates`.
